### PR TITLE
✨ Restore Cinemeta calendar functionality

### DIFF
--- a/public/presets/en.json
+++ b/public/presets/en.json
@@ -2,6 +2,605 @@
   "result": {
     "addons": [
       {
+        "transportUrl": "https://v3-cinemeta.strem.io/manifest.json",
+        "transportName": "http",
+        "manifest": {
+          "id": "com.linvo.cinemeta",
+          "version": "3.0.13",
+          "description": "The official addon for movie and series catalogs",
+          "name": "Cinemeta",
+          "resources": [
+            "catalog",
+            "meta",
+            "addon_catalog"
+          ],
+          "types": [
+            "movie",
+            "series"
+          ],
+          "idPrefixes": [
+            "tt"
+          ],
+          "addonCatalogs": [
+            {
+              "type": "all",
+              "id": "official",
+              "name": "Official"
+            },
+            {
+              "type": "movie",
+              "id": "official",
+              "name": "Official"
+            },
+            {
+              "type": "series",
+              "id": "official",
+              "name": "Official"
+            },
+            {
+              "type": "channel",
+              "id": "official",
+              "name": "Official"
+            },
+            {
+              "type": "all",
+              "id": "community",
+              "name": "Community"
+            },
+            {
+              "type": "movie",
+              "id": "community",
+              "name": "Community"
+            },
+            {
+              "type": "series",
+              "id": "community",
+              "name": "Community"
+            },
+            {
+              "type": "channel",
+              "id": "community",
+              "name": "Community"
+            },
+            {
+              "type": "tv",
+              "id": "community",
+              "name": "Community"
+            },
+            {
+              "type": "Podcasts",
+              "id": "community",
+              "name": "Community"
+            },
+            {
+              "type": "other",
+              "id": "community",
+              "name": "Community"
+            }
+          ],
+          "catalogs": [
+            {
+              "name": "Cinemeta Search Movies",
+              "type": "movie",
+              "id": "cinemeta.search",
+              "extra": [
+                {
+                  "name": "search",
+                  "isRequired": true
+                }
+              ]
+            },
+            {
+              "name": "Cinemeta Search TV Shows",
+              "type": "series",
+              "id": "cinemeta.search",
+              "extra": [
+                {
+                  "name": "search",
+                  "isRequired": true
+                }
+              ]
+            },
+            {
+              "type": "series",
+              "id": "last-videos",
+              "name": "Last videos",
+              "extra": [
+                {
+                  "name": "lastVideosIds",
+                  "isRequired": true,
+                  "optionsLimit": 100
+                }
+              ],
+              "extraSupported": [
+                "lastVideosIds"
+              ],
+              "extraRequired": [
+                "lastVideosIds"
+              ]
+            },
+            {
+              "type": "series",
+              "id": "calendar-videos",
+              "extra": [
+                {
+                  "name": "calendarVideosIds",
+                  "isRequired": true,
+                  "optionsLimit": 100
+                }
+              ],
+              "extraSupported": [
+                "calendarVideosIds"
+              ],
+              "extraRequired": [
+                "calendarVideosIds"
+              ],
+              "name": "Calendar videos"
+            }
+          ],
+          "behaviorHints": {
+            "newEpisodeNotifications": true
+          }
+        },
+        "flags": {
+          "official": true,
+          "protected": true
+        }
+      },
+      {
+        "transportUrl": "https://94c8cb9f702d-tmdb-addon.baby-beamup.club/%7B%22provide_imdbId%22%3A%22true%22%2C%22language%22%3A%22en-US%22%7D/manifest.json",
+        "transportName": "",
+        "manifest": {
+          "id": "tmdb-addon",
+          "version": "3.0.18",
+          "name": "The Movie Database Addon",
+          "contactEmail": null,
+          "description": "Metadata provided by TMDB with en-US language.",
+          "logo": "https://github.com/mrcanelas/tmdb-addon/raw/main/images/logo.png",
+          "background": "https://github.com/mrcanelas/tmdb-addon/raw/main/images/background.png",
+          "types": [
+            "movie",
+            "series"
+          ],
+          "resources": [
+            "catalog",
+            "meta"
+          ],
+          "idPrefixes": [
+            "tmdb:",
+            "tt"
+          ],
+          "catalogs": [
+            {
+              "id": "tmdb.top",
+              "type": "movie",
+              "name": "Popular",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "",
+                    "Action",
+                    "Adventure",
+                    "Animation",
+                    "Comedy",
+                    "Crime",
+                    "Documentary",
+                    "Drama",
+                    "Family",
+                    "Fantasy",
+                    "History",
+                    "Horror",
+                    "Music",
+                    "Mystery",
+                    "Romance",
+                    "Science Fiction",
+                    "TV Movie",
+                    "Thriller",
+                    "War",
+                    "Western"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "search",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "id": "tmdb.year",
+              "type": "movie",
+              "name": "Year",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "2025",
+                    "2024",
+                    "2023",
+                    "2022",
+                    "2021",
+                    "2020",
+                    "2019",
+                    "2018",
+                    "2017",
+                    "2016",
+                    "2015",
+                    "2014",
+                    "2013",
+                    "2012",
+                    "2011",
+                    "2010",
+                    "2009",
+                    "2008",
+                    "2007",
+                    "2006",
+                    "2005"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "id": "tmdb.language",
+              "type": "movie",
+              "name": "Language",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "English",
+                    "Afrikaans",
+                    "Albanian",
+                    "Arabic",
+                    "Basque",
+                    "Belarusian",
+                    "Bengali",
+                    "Breton",
+                    "Bulgarian",
+                    "Catalan",
+                    "Chamorro",
+                    "Croatian",
+                    "Czech",
+                    "Danish",
+                    "Dutch",
+                    "Esperanto",
+                    "Estonian",
+                    "Finnish",
+                    "French",
+                    "Gaelic",
+                    "Galician",
+                    "Georgian",
+                    "German",
+                    "Greek",
+                    "Hebrew",
+                    "Hindi",
+                    "Hungarian",
+                    "Indonesian",
+                    "Irish",
+                    "Italian",
+                    "Japanese",
+                    "Kannada",
+                    "Kazakh",
+                    "Kirghiz",
+                    "Korean",
+                    "Kurdish",
+                    "Latvian",
+                    "Lithuanian",
+                    "Malay",
+                    "Malayalam",
+                    "Mandarin",
+                    "Marathi",
+                    "Norwegian",
+                    "Norwegian Bokmål",
+                    "Persian",
+                    "Polish",
+                    "Portuguese",
+                    "Punjabi",
+                    "Romanian",
+                    "Russian",
+                    "Serbian",
+                    "Sinhalese",
+                    "Slovak",
+                    "Slovenian",
+                    "Somali",
+                    "Spanish",
+                    "Swahili",
+                    "Swedish",
+                    "Tagalog",
+                    "Tamil",
+                    "Telugu",
+                    "Thai",
+                    "Turkish",
+                    "Ukrainian",
+                    "Urdu",
+                    "Uzbek",
+                    "Vietnamese",
+                    "Welsh",
+                    "Zulu"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "id": "tmdb.trending",
+              "type": "movie",
+              "name": "Trending",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "Day",
+                    "Week"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "id": "tmdb.top",
+              "type": "series",
+              "name": "Popular",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "",
+                    "Action & Adventure",
+                    "Animation",
+                    "Comedy",
+                    "Crime",
+                    "Documentary",
+                    "Drama",
+                    "Family",
+                    "Kids",
+                    "Mystery",
+                    "News",
+                    "Reality",
+                    "Sci-Fi & Fantasy",
+                    "Soap",
+                    "Talk",
+                    "War & Politics",
+                    "Western"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "search",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "id": "tmdb.year",
+              "type": "series",
+              "name": "Year",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "2025",
+                    "2024",
+                    "2023",
+                    "2022",
+                    "2021",
+                    "2020",
+                    "2019",
+                    "2018",
+                    "2017",
+                    "2016",
+                    "2015",
+                    "2014",
+                    "2013",
+                    "2012",
+                    "2011",
+                    "2010",
+                    "2009",
+                    "2008",
+                    "2007",
+                    "2006",
+                    "2005"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "id": "tmdb.language",
+              "type": "series",
+              "name": "Language",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "English",
+                    "Afrikaans",
+                    "Albanian",
+                    "Arabic",
+                    "Basque",
+                    "Belarusian",
+                    "Bengali",
+                    "Breton",
+                    "Bulgarian",
+                    "Catalan",
+                    "Chamorro",
+                    "Croatian",
+                    "Czech",
+                    "Danish",
+                    "Dutch",
+                    "Esperanto",
+                    "Estonian",
+                    "Finnish",
+                    "French",
+                    "Gaelic",
+                    "Galician",
+                    "Georgian",
+                    "German",
+                    "Greek",
+                    "Hebrew",
+                    "Hindi",
+                    "Hungarian",
+                    "Indonesian",
+                    "Irish",
+                    "Italian",
+                    "Japanese",
+                    "Kannada",
+                    "Kazakh",
+                    "Kirghiz",
+                    "Korean",
+                    "Kurdish",
+                    "Latvian",
+                    "Lithuanian",
+                    "Malay",
+                    "Malayalam",
+                    "Mandarin",
+                    "Marathi",
+                    "Norwegian",
+                    "Norwegian Bokmål",
+                    "Persian",
+                    "Polish",
+                    "Portuguese",
+                    "Punjabi",
+                    "Romanian",
+                    "Russian",
+                    "Serbian",
+                    "Sinhalese",
+                    "Slovak",
+                    "Slovenian",
+                    "Somali",
+                    "Spanish",
+                    "Swahili",
+                    "Swedish",
+                    "Tagalog",
+                    "Tamil",
+                    "Telugu",
+                    "Thai",
+                    "Turkish",
+                    "Ukrainian",
+                    "Urdu",
+                    "Uzbek",
+                    "Vietnamese",
+                    "Welsh",
+                    "Zulu"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "id": "tmdb.trending",
+              "type": "series",
+              "name": "Trending",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "Day",
+                    "Week"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "name": "TMDB Search Movies",
+              "type": "movie",
+              "id": "tmdb.search",
+              "extra": [
+                {
+                  "name": "search",
+                  "isRequired": true
+                }
+              ]
+            },
+            {
+              "name": "TMDB Search TV Shows",
+              "type": "series",
+              "id": "tmdb.search",
+              "extra": [
+                {
+                  "name": "search",
+                  "isRequired": true
+                }
+              ]
+            }
+          ],
+          "addonCatalogs": [],
+          "behaviorHints": {
+            "adult": false,
+            "p2p": false,
+            "configurable": true,
+            "configurationRequired": false
+          }
+        },
+        "flags": {
+          "official": false,
+          "protected": false
+        }
+      },
+      {
         "transportUrl": "https://2ecbbd610840-trakt.baby-beamup.club/eyJsaXN0cyI6W10sImlkcyI6WyJnYXJ5Y3Jhd2ZvcmRnYzpsYXRlc3QtcmVsZWFzZXM6cmVsZWFzZWQsYXNjIiwiZ2FyeWNyYXdmb3JkZ2M6bGF0ZXN0LXR2LXNob3dzOnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOnRvcC1tb3ZpZXMtb2YtdGhlLXdlZWs6cmVsZWFzZWQsYXNjIiwiZ2FyeWNyYXdmb3JkZ2M6bmV0ZmxpeC1tb3ZpZXM6cmVsZWFzZWQsYXNjIiwiZ2FyeWNyYXdmb3JkZ2M6bmV0ZmxpeC1zaG93czpyZWxlYXNlZCxhc2MiLCJnYXJ5Y3Jhd2ZvcmRnYzpkaXNuZXktbW92aWVzOnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOmRpc25leS1zaG93czpyZWxlYXNlZCxhc2MiLCJnYXJ5Y3Jhd2ZvcmRnYzphbWF6b24tcHJpbWUtbW92aWVzOnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOmFtYXpvbi1wcmltZS1zaG93czpyZWxlYXNlZCxhc2MiLCJnYXJ5Y3Jhd2ZvcmRnYzpodWx1LW1vdmllczpyZWxlYXNlZCxhc2MiLCJnYXJ5Y3Jhd2ZvcmRnYzpodWx1LXNob3dzOnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOmhiby1zaG93czpyZWxlYXNlZCxhc2MiLCJnYXJ5Y3Jhd2ZvcmRnYzphY3Rpb246cmVsZWFzZWQsYXNjIiwicml6cmVmbGVjdHM6YWR2ZW50dXJlLW1vdmllczpyZWxlYXNlZCxhc2MiLCJyaXpyZWZsZWN0czphbmltYXRpb246cmVsZWFzZWQsYXNjIiwiZ2FyeWNyYXdmb3JkZ2M6Y29tZWR5OnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOmNyaW1lOnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOmRyYW1hOnJlbGVhc2VkLGFzYyIsInJpenJlZmxlY3RzOmZhbnRhc3ktbW92aWVzOnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOmhvcnJvcjpyZWxlYXNlZCxhc2MiLCJyaXpyZWZsZWN0czpteXN0ZXJ5LW1vdmllczpyZWxlYXNlZCxhc2MiLCJyaXpyZWZsZWN0czpyb21hbmNlOnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOnNjaS1maTpyZWxlYXNlZCxhc2MiLCJnYXJ5Y3Jhd2ZvcmRnYzp0aHJpbGxlcjpyZWxlYXNlZCxhc2MiXX0=/manifest.json",
         "transportName": "",
         "manifest": {
@@ -1198,459 +1797,6 @@
         }
       },
       {
-        "transportUrl": "https://94c8cb9f702d-tmdb-addon.baby-beamup.club/%7B%22provide_imdbId%22%3A%22true%22%2C%22language%22%3A%22en-US%22%7D/manifest.json",
-        "transportName": "",
-        "manifest": {
-          "id": "tmdb-addon",
-          "version": "3.0.18",
-          "name": "The Movie Database Addon",
-          "contactEmail": null,
-          "description": "Metadata provided by TMDB with en-US language.",
-          "logo": "https://github.com/mrcanelas/tmdb-addon/raw/main/images/logo.png",
-          "background": "https://github.com/mrcanelas/tmdb-addon/raw/main/images/background.png",
-          "types": [
-            "movie",
-            "series"
-          ],
-          "resources": [
-            "catalog",
-            "meta"
-          ],
-          "idPrefixes": [
-            "tmdb:",
-            "tt"
-          ],
-          "catalogs": [
-            {
-              "id": "tmdb.top",
-              "type": "movie",
-              "name": "Popular",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "",
-                    "Action",
-                    "Adventure",
-                    "Animation",
-                    "Comedy",
-                    "Crime",
-                    "Documentary",
-                    "Drama",
-                    "Family",
-                    "Fantasy",
-                    "History",
-                    "Horror",
-                    "Music",
-                    "Mystery",
-                    "Romance",
-                    "Science Fiction",
-                    "TV Movie",
-                    "Thriller",
-                    "War",
-                    "Western"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "search",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "id": "tmdb.year",
-              "type": "movie",
-              "name": "Year",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "2024",
-                    "2023",
-                    "2022",
-                    "2021",
-                    "2020",
-                    "2019",
-                    "2018",
-                    "2017",
-                    "2016",
-                    "2015",
-                    "2014",
-                    "2013",
-                    "2012",
-                    "2011",
-                    "2010",
-                    "2009",
-                    "2008",
-                    "2007",
-                    "2006",
-                    "2005",
-                    "2004"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "id": "tmdb.language",
-              "type": "movie",
-              "name": "Language",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "English",
-                    "Afrikaans",
-                    "Albanian",
-                    "Arabic",
-                    "Basque",
-                    "Belarusian",
-                    "Bengali",
-                    "Breton",
-                    "Bulgarian",
-                    "Catalan",
-                    "Chamorro",
-                    "Croatian",
-                    "Czech",
-                    "Danish",
-                    "Dutch",
-                    "Esperanto",
-                    "Estonian",
-                    "Finnish",
-                    "French",
-                    "Gaelic",
-                    "Galician",
-                    "Georgian",
-                    "German",
-                    "Greek",
-                    "Hebrew",
-                    "Hindi",
-                    "Hungarian",
-                    "Indonesian",
-                    "Irish",
-                    "Italian",
-                    "Japanese",
-                    "Kannada",
-                    "Kazakh",
-                    "Kirghiz",
-                    "Korean",
-                    "Kurdish",
-                    "Latvian",
-                    "Lithuanian",
-                    "Malay",
-                    "Malayalam",
-                    "Mandarin",
-                    "Marathi",
-                    "Norwegian",
-                    "Norwegian Bokmål",
-                    "Persian",
-                    "Polish",
-                    "Portuguese",
-                    "Punjabi",
-                    "Romanian",
-                    "Russian",
-                    "Serbian",
-                    "Sinhalese",
-                    "Slovak",
-                    "Slovenian",
-                    "Somali",
-                    "Spanish",
-                    "Swahili",
-                    "Swedish",
-                    "Tagalog",
-                    "Tamil",
-                    "Telugu",
-                    "Thai",
-                    "Turkish",
-                    "Ukrainian",
-                    "Urdu",
-                    "Uzbek",
-                    "Vietnamese",
-                    "Welsh",
-                    "Zulu"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "id": "tmdb.trending",
-              "type": "movie",
-              "name": "Trending",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "Day",
-                    "Week"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "id": "tmdb.top",
-              "type": "series",
-              "name": "Popular",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "",
-                    "Action & Adventure",
-                    "Animation",
-                    "Comedy",
-                    "Crime",
-                    "Documentary",
-                    "Drama",
-                    "Family",
-                    "Kids",
-                    "Mystery",
-                    "News",
-                    "Reality",
-                    "Sci-Fi & Fantasy",
-                    "Soap",
-                    "Talk",
-                    "War & Politics",
-                    "Western"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "search",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "id": "tmdb.year",
-              "type": "series",
-              "name": "Year",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "2024",
-                    "2023",
-                    "2022",
-                    "2021",
-                    "2020",
-                    "2019",
-                    "2018",
-                    "2017",
-                    "2016",
-                    "2015",
-                    "2014",
-                    "2013",
-                    "2012",
-                    "2011",
-                    "2010",
-                    "2009",
-                    "2008",
-                    "2007",
-                    "2006",
-                    "2005",
-                    "2004"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "id": "tmdb.language",
-              "type": "series",
-              "name": "Language",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "English",
-                    "Afrikaans",
-                    "Albanian",
-                    "Arabic",
-                    "Basque",
-                    "Belarusian",
-                    "Bengali",
-                    "Breton",
-                    "Bulgarian",
-                    "Catalan",
-                    "Chamorro",
-                    "Croatian",
-                    "Czech",
-                    "Danish",
-                    "Dutch",
-                    "Esperanto",
-                    "Estonian",
-                    "Finnish",
-                    "French",
-                    "Gaelic",
-                    "Galician",
-                    "Georgian",
-                    "German",
-                    "Greek",
-                    "Hebrew",
-                    "Hindi",
-                    "Hungarian",
-                    "Indonesian",
-                    "Irish",
-                    "Italian",
-                    "Japanese",
-                    "Kannada",
-                    "Kazakh",
-                    "Kirghiz",
-                    "Korean",
-                    "Kurdish",
-                    "Latvian",
-                    "Lithuanian",
-                    "Malay",
-                    "Malayalam",
-                    "Mandarin",
-                    "Marathi",
-                    "Norwegian",
-                    "Norwegian Bokmål",
-                    "Persian",
-                    "Polish",
-                    "Portuguese",
-                    "Punjabi",
-                    "Romanian",
-                    "Russian",
-                    "Serbian",
-                    "Sinhalese",
-                    "Slovak",
-                    "Slovenian",
-                    "Somali",
-                    "Spanish",
-                    "Swahili",
-                    "Swedish",
-                    "Tagalog",
-                    "Tamil",
-                    "Telugu",
-                    "Thai",
-                    "Turkish",
-                    "Ukrainian",
-                    "Urdu",
-                    "Uzbek",
-                    "Vietnamese",
-                    "Welsh",
-                    "Zulu"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "id": "tmdb.trending",
-              "type": "series",
-              "name": "Trending",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "Day",
-                    "Week"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "name": "TMDB Search Movies",
-              "type": "movie",
-              "id": "tmdb.search",
-              "extra": [
-                {
-                  "name": "search",
-                  "isRequired": true
-                }
-              ]
-            },
-            {
-              "name": "TMDB Search TV Shows",
-              "type": "series",
-              "id": "tmdb.search",
-              "extra": [
-                {
-                  "name": "search",
-                  "isRequired": true
-                }
-              ]
-            }
-          ],
-          "addonCatalogs": [],
-          "behaviorHints": {
-            "adult": false,
-            "p2p": false,
-            "configurable": true,
-            "configurationRequired": false
-          }
-        },
-        "flags": {
-          "official": false,
-          "protected": false
-        }
-      },
-      {
         "transportUrl": "https://jackettio.elfhosted.com/eyJtYXhUb3JyZW50cyI6MTAsInByaW90aXplUGFja1RvcnJlbnRzIjoyLCJleGNsdWRlS2V5d29yZHMiOlsiQ0FNIiwiVGVsZVN5bmMiLCJUZWxlQ2luZSIsIlNDUiJdLCJkZWJyaWRJZCI6InJlYWxkZWJyaWQiLCJoaWRlVW5jYWNoZWQiOmZhbHNlLCJzb3J0Q2FjaGVkIjpbWyJxdWFsaXR5Iix0cnVlXSxbInNpemUiLHRydWVdXSwic29ydFVuY2FjaGVkIjpbWyJxdWFsaXR5Iix0cnVlXSxbInNlZWRlcnMiLHRydWVdXSwiZm9yY2VDYWNoZU5leHRFcGlzb2RlIjp0cnVlLCJwcmlvdGl6ZUxhbmd1YWdlcyI6WyJlbmdsaXNoIl0sImluZGV4ZXJUaW1lb3V0U2VjIjo2MCwibWV0YUxhbmd1YWdlIjoiIiwiZW5hYmxlTWVkaWFGbG93IjpmYWxzZSwibWVkaWFmbG93UHJveHlVcmwiOiIiLCJtZWRpYWZsb3dBcGlQYXNzd29yZCI6IiIsIm1lZGlhZmxvd1B1YmxpY0lwIjoiIiwicXVhbGl0aWVzIjpbNDgwLDcyMCwxMDgwLDIxNjBdLCJpbmRleGVycyI6WyJiaXRzZWFyY2giLCJlenR2IiwidGhlcGlyYXRlYmF5IiwidGhlcmFyYmciLCJ5dHMiXSwiZGVicmlkQXBpS2V5IjoiMCJ9/manifest.json",
         "transportName": "",
         "manifest": {
@@ -1844,116 +1990,6 @@
         "flags": {
           "official": false,
           "protected": false
-        }
-      },
-      {
-        "transportUrl": "https://v3-cinemeta.strem.io/manifest.json",
-        "transportName": "http",
-        "manifest": {
-          "id": "com.linvo.cinemeta",
-          "version": "3.0.12",
-          "description": "The official addon for movie and series catalogs",
-          "name": "Cinemeta",
-          "resources": [
-            "meta",
-            "addon_catalog",
-            "catalog"
-          ],
-          "types": [
-            "movie",
-            "series"
-          ],
-          "idPrefixes": [
-            "tt"
-          ],
-          "addonCatalogs": [
-            {
-              "type": "all",
-              "id": "official",
-              "name": "Official"
-            },
-            {
-              "type": "movie",
-              "id": "official",
-              "name": "Official"
-            },
-            {
-              "type": "series",
-              "id": "official",
-              "name": "Official"
-            },
-            {
-              "type": "channel",
-              "id": "official",
-              "name": "Official"
-            },
-            {
-              "type": "all",
-              "id": "community",
-              "name": "Community"
-            },
-            {
-              "type": "movie",
-              "id": "community",
-              "name": "Community"
-            },
-            {
-              "type": "series",
-              "id": "community",
-              "name": "Community"
-            },
-            {
-              "type": "channel",
-              "id": "community",
-              "name": "Community"
-            },
-            {
-              "type": "tv",
-              "id": "community",
-              "name": "Community"
-            },
-            {
-              "type": "Podcasts",
-              "id": "community",
-              "name": "Community"
-            },
-            {
-              "type": "other",
-              "id": "community",
-              "name": "Community"
-            }
-          ],
-          "catalogs": [
-            {
-              "name": "Cinemeta Search Movies",
-              "type": "movie",
-              "id": "cinemeta.search",
-              "extra": [
-                {
-                  "name": "search",
-                  "isRequired": true
-                }
-              ]
-            },
-            {
-              "name": "Cinemeta Search TV Shows",
-              "type": "series",
-              "id": "cinemeta.search",
-              "extra": [
-                {
-                  "name": "search",
-                  "isRequired": true
-                }
-              ]
-            }
-          ],
-          "behaviorHints": {
-            "newEpisodeNotifications": true
-          }
-        },
-        "flags": {
-          "official": true,
-          "protected": true
         }
       },
       {

--- a/public/presets/es.json
+++ b/public/presets/es.json
@@ -2,6 +2,604 @@
   "result": {
     "addons": [
       {
+        "transportUrl": "https://v3-cinemeta.strem.io/manifest.json",
+        "transportName": "http",
+        "manifest": {
+          "id": "com.linvo.cinemeta",
+          "version": "3.0.13",
+          "description": "The official addon for movie and series catalogs",
+          "name": "Cinemeta",
+          "resources": [
+            "catalog",
+            "meta",
+            "addon_catalog"
+          ],
+          "types": [
+            "movie",
+            "series"
+          ],
+          "idPrefixes": [
+            "tt"
+          ],
+          "addonCatalogs": [
+            {
+              "type": "all",
+              "id": "official",
+              "name": "Official"
+            },
+            {
+              "type": "movie",
+              "id": "official",
+              "name": "Official"
+            },
+            {
+              "type": "series",
+              "id": "official",
+              "name": "Official"
+            },
+            {
+              "type": "channel",
+              "id": "official",
+              "name": "Official"
+            },
+            {
+              "type": "all",
+              "id": "community",
+              "name": "Community"
+            },
+            {
+              "type": "movie",
+              "id": "community",
+              "name": "Community"
+            },
+            {
+              "type": "series",
+              "id": "community",
+              "name": "Community"
+            },
+            {
+              "type": "channel",
+              "id": "community",
+              "name": "Community"
+            },
+            {
+              "type": "tv",
+              "id": "community",
+              "name": "Community"
+            },
+            {
+              "type": "Podcasts",
+              "id": "community",
+              "name": "Community"
+            },
+            {
+              "type": "other",
+              "id": "community",
+              "name": "Community"
+            }
+          ],
+          "catalogs": [
+            {
+              "name": "Cinemeta Search Movies",
+              "type": "movie",
+              "id": "cinemeta.search",
+              "extra": [
+                {
+                  "name": "search",
+                  "isRequired": true
+                }
+              ]
+            },
+            {
+              "name": "Cinemeta Search TV Shows",
+              "type": "series",
+              "id": "cinemeta.search",
+              "extra": [
+                {
+                  "name": "search",
+                  "isRequired": true
+                }
+              ]
+            },
+            {
+              "type": "series",
+              "id": "last-videos",
+              "name": "Últimos vídeos",
+              "extra": [
+                {
+                  "name": "lastVideosIds",
+                  "isRequired": true,
+                  "optionsLimit": 100
+                }
+              ],
+              "extraSupported": [
+                "lastVideosIds"
+              ],
+              "extraRequired": [
+                "lastVideosIds"
+              ]
+            },
+            {
+              "type": "series",
+              "id": "calendar-videos",
+              "extra": [
+                {
+                  "name": "calendarVideosIds",
+                  "isRequired": true,
+                  "optionsLimit": 100
+                }
+              ],
+              "extraSupported": [
+                "calendarVideosIds"
+              ],
+              "extraRequired": [
+                "calendarVideosIds"
+              ],
+              "name": "Vídeos de calendario"
+            }
+          ],
+          "behaviorHints": {
+            "newEpisodeNotifications": true
+          }
+        },
+        "flags": {
+          "official": true,
+          "protected": true
+        }
+      },
+      {
+        "transportUrl": "https://94c8cb9f702d-tmdb-addon.baby-beamup.club/%7B%22provide_imdbId%22%3A%22true%22%2C%22language%22%3A%22es-MX%22%7D/manifest.json",
+        "transportName": "",
+        "manifest": {
+          "id": "tmdb-addon",
+          "version": "3.0.18",
+          "name": "The Movie Database Addon",
+          "contactEmail": null,
+          "description": "Metadata provided by TMDB with es-MX language.",
+          "logo": "https://github.com/mrcanelas/tmdb-addon/raw/main/images/logo.png",
+          "background": "https://github.com/mrcanelas/tmdb-addon/raw/main/images/background.png",
+          "types": [
+            "movie",
+            "series"
+          ],
+          "resources": [
+            "catalog",
+            "meta"
+          ],
+          "idPrefixes": [
+            "tmdb:",
+            "tt"
+          ],
+          "catalogs": [
+            {
+              "id": "tmdb.top",
+              "type": "movie",
+              "name": "Popular",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "",
+                    "Acción",
+                    "Animación",
+                    "Aventura",
+                    "Bélica",
+                    "Ciencia ficción",
+                    "Comedia",
+                    "Crimen",
+                    "Documental",
+                    "Drama",
+                    "Familia",
+                    "Fantasía",
+                    "Historia",
+                    "Misterio",
+                    "Música",
+                    "Película de TV",
+                    "Romance",
+                    "Suspense",
+                    "Terror",
+                    "Western"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "search",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "id": "tmdb.year",
+              "type": "movie",
+              "name": "Año",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "2025",
+                    "2024",
+                    "2023",
+                    "2022",
+                    "2021",
+                    "2020",
+                    "2019",
+                    "2018",
+                    "2017",
+                    "2016",
+                    "2015",
+                    "2014",
+                    "2013",
+                    "2012",
+                    "2011",
+                    "2010",
+                    "2009",
+                    "2008",
+                    "2007",
+                    "2006",
+                    "2005"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "id": "tmdb.language",
+              "type": "movie",
+              "name": "Idioma",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "Spanish",
+                    "Afrikaans",
+                    "Albanian",
+                    "Arabic",
+                    "Basque",
+                    "Belarusian",
+                    "Bengali",
+                    "Breton",
+                    "Bulgarian",
+                    "Catalan",
+                    "Chamorro",
+                    "Croatian",
+                    "Czech",
+                    "Danish",
+                    "Dutch",
+                    "English",
+                    "Esperanto",
+                    "Estonian",
+                    "Finnish",
+                    "French",
+                    "Gaelic",
+                    "Galician",
+                    "Georgian",
+                    "German",
+                    "Greek",
+                    "Hebrew",
+                    "Hindi",
+                    "Hungarian",
+                    "Indonesian",
+                    "Irish",
+                    "Italian",
+                    "Japanese",
+                    "Kannada",
+                    "Kazakh",
+                    "Kirghiz",
+                    "Korean",
+                    "Kurdish",
+                    "Latvian",
+                    "Lithuanian",
+                    "Malay",
+                    "Malayalam",
+                    "Mandarin",
+                    "Marathi",
+                    "Norwegian",
+                    "Norwegian Bokmål",
+                    "Persian",
+                    "Polish",
+                    "Portuguese",
+                    "Punjabi",
+                    "Romanian",
+                    "Russian",
+                    "Serbian",
+                    "Sinhalese",
+                    "Slovak",
+                    "Slovenian",
+                    "Somali",
+                    "Swahili",
+                    "Swedish",
+                    "Tagalog",
+                    "Tamil",
+                    "Telugu",
+                    "Thai",
+                    "Turkish",
+                    "Ukrainian",
+                    "Urdu",
+                    "Uzbek",
+                    "Vietnamese",
+                    "Welsh",
+                    "Zulu"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "id": "tmdb.trending",
+              "type": "movie",
+              "name": "Tendencia",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "Day",
+                    "Week"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "id": "tmdb.top",
+              "type": "series",
+              "name": "Popular",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "",
+                    "Action & Adventure",
+                    "Animación",
+                    "Comedia",
+                    "Crimen",
+                    "Documental",
+                    "Drama",
+                    "Familia",
+                    "Kids",
+                    "Misterio",
+                    "News",
+                    "Reality",
+                    "Sci-Fi & Fantasy",
+                    "Soap",
+                    "Talk",
+                    "War & Politics",
+                    "Western"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "search",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "id": "tmdb.year",
+              "type": "series",
+              "name": "Año",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "2024",
+                    "2023",
+                    "2022",
+                    "2021",
+                    "2020",
+                    "2019",
+                    "2018",
+                    "2017",
+                    "2016",
+                    "2015",
+                    "2014",
+                    "2013",
+                    "2012",
+                    "2011",
+                    "2010",
+                    "2009",
+                    "2008",
+                    "2007",
+                    "2006",
+                    "2005"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "id": "tmdb.language",
+              "type": "series",
+              "name": "Idioma",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "Spanish",
+                    "Afrikaans",
+                    "Albanian",
+                    "Arabic",
+                    "Basque",
+                    "Belarusian",
+                    "Bengali",
+                    "Breton",
+                    "Bulgarian",
+                    "Catalan",
+                    "Chamorro",
+                    "Croatian",
+                    "Czech",
+                    "Danish",
+                    "Dutch",
+                    "English",
+                    "Esperanto",
+                    "Estonian",
+                    "Finnish",
+                    "French",
+                    "Gaelic",
+                    "Galician",
+                    "Georgian",
+                    "German",
+                    "Greek",
+                    "Hebrew",
+                    "Hindi",
+                    "Hungarian",
+                    "Indonesian",
+                    "Irish",
+                    "Italian",
+                    "Japanese",
+                    "Kannada",
+                    "Kazakh",
+                    "Kirghiz",
+                    "Korean",
+                    "Kurdish",
+                    "Latvian",
+                    "Lithuanian",
+                    "Malay",
+                    "Malayalam",
+                    "Mandarin",
+                    "Marathi",
+                    "Norwegian",
+                    "Norwegian Bokmål",
+                    "Persian",
+                    "Polish",
+                    "Portuguese",
+                    "Punjabi",
+                    "Romanian",
+                    "Russian",
+                    "Serbian",
+                    "Sinhalese",
+                    "Slovak",
+                    "Slovenian",
+                    "Somali",
+                    "Swahili",
+                    "Swedish",
+                    "Tagalog",
+                    "Tamil",
+                    "Telugu",
+                    "Thai",
+                    "Turkish",
+                    "Ukrainian",
+                    "Urdu",
+                    "Uzbek",
+                    "Vietnamese",
+                    "Welsh",
+                    "Zulu"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "id": "tmdb.trending",
+              "type": "series",
+              "name": "Tendencia",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "Day",
+                    "Week"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "name": "TMDB Búsqueda Películas",
+              "type": "movie",
+              "id": "tmdb.search",
+              "extra": [
+                {
+                  "name": "search",
+                  "isRequired": true
+                }
+              ]
+            },
+            {
+              "name": "TMDB Búsqueda Series",
+              "type": "series",
+              "id": "tmdb.search",
+              "extra": [
+                {
+                  "name": "search",
+                  "isRequired": true
+                }
+              ]
+            }
+          ],
+          "addonCatalogs": [],
+          "behaviorHints": {
+            "adult": false,
+            "p2p": false,
+            "configurable": true,
+            "configurationRequired": false
+          }
+        },
+        "flags": {
+          "official": false,
+          "protected": false
+        }
+      },
+      {
         "transportUrl": "https://2ecbbd610840-trakt.baby-beamup.club/eyJsaXN0cyI6W10sImlkcyI6WyJnYXJ5Y3Jhd2ZvcmRnYzpsYXRlc3QtcmVsZWFzZXM6cmVsZWFzZWQsYXNjIiwiZ2FyeWNyYXdmb3JkZ2M6bGF0ZXN0LXR2LXNob3dzOnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOnRvcC1tb3ZpZXMtb2YtdGhlLXdlZWs6cmVsZWFzZWQsYXNjIiwiZ2FyeWNyYXdmb3JkZ2M6bmV0ZmxpeC1tb3ZpZXM6cmVsZWFzZWQsYXNjIiwiZ2FyeWNyYXdmb3JkZ2M6bmV0ZmxpeC1zaG93czpyZWxlYXNlZCxhc2MiLCJnYXJ5Y3Jhd2ZvcmRnYzpkaXNuZXktbW92aWVzOnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOmRpc25leS1zaG93czpyZWxlYXNlZCxhc2MiLCJnYXJ5Y3Jhd2ZvcmRnYzphbWF6b24tcHJpbWUtbW92aWVzOnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOmFtYXpvbi1wcmltZS1zaG93czpyZWxlYXNlZCxhc2MiLCJnYXJ5Y3Jhd2ZvcmRnYzpodWx1LW1vdmllczpyZWxlYXNlZCxhc2MiLCJnYXJ5Y3Jhd2ZvcmRnYzpodWx1LXNob3dzOnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOmhiby1zaG93czpyZWxlYXNlZCxhc2MiLCJnYXJ5Y3Jhd2ZvcmRnYzphY3Rpb246cmVsZWFzZWQsYXNjIiwicml6cmVmbGVjdHM6YWR2ZW50dXJlLW1vdmllczpyZWxlYXNlZCxhc2MiLCJyaXpyZWZsZWN0czphbmltYXRpb246cmVsZWFzZWQsYXNjIiwiZ2FyeWNyYXdmb3JkZ2M6Y29tZWR5OnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOmNyaW1lOnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOmRyYW1hOnJlbGVhc2VkLGFzYyIsInJpenJlZmxlY3RzOmZhbnRhc3ktbW92aWVzOnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOmhvcnJvcjpyZWxlYXNlZCxhc2MiLCJyaXpyZWZsZWN0czpteXN0ZXJ5LW1vdmllczpyZWxlYXNlZCxhc2MiLCJyaXpyZWZsZWN0czpyb21hbmNlOnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOnNjaS1maTpyZWxlYXNlZCxhc2MiLCJnYXJ5Y3Jhd2ZvcmRnYzp0aHJpbGxlcjpyZWxlYXNlZCxhc2MiXX0=/manifest.json",
         "transportName": "",
         "manifest": {
@@ -1198,459 +1796,6 @@
         }
       },
       {
-        "transportUrl": "https://94c8cb9f702d-tmdb-addon.baby-beamup.club/%7B%22provide_imdbId%22%3A%22true%22%2C%22language%22%3A%22es-MX%22%7D/manifest.json",
-        "transportName": "",
-        "manifest": {
-          "id": "tmdb-addon",
-          "version": "3.0.18",
-          "name": "The Movie Database Addon",
-          "contactEmail": null,
-          "description": "Metadata provided by TMDB with es-MX language.",
-          "logo": "https://github.com/mrcanelas/tmdb-addon/raw/main/images/logo.png",
-          "background": "https://github.com/mrcanelas/tmdb-addon/raw/main/images/background.png",
-          "types": [
-            "movie",
-            "series"
-          ],
-          "resources": [
-            "catalog",
-            "meta"
-          ],
-          "idPrefixes": [
-            "tmdb:",
-            "tt"
-          ],
-          "catalogs": [
-            {
-              "id": "tmdb.top",
-              "type": "movie",
-              "name": "Popular",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "",
-                    "Acción",
-                    "Animación",
-                    "Aventura",
-                    "Bélica",
-                    "Ciencia ficción",
-                    "Comedia",
-                    "Crimen",
-                    "Documental",
-                    "Drama",
-                    "Familia",
-                    "Fantasía",
-                    "Historia",
-                    "Misterio",
-                    "Música",
-                    "Película de TV",
-                    "Romance",
-                    "Suspense",
-                    "Terror",
-                    "Western"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "search",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "id": "tmdb.year",
-              "type": "movie",
-              "name": "Año",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "2024",
-                    "2023",
-                    "2022",
-                    "2021",
-                    "2020",
-                    "2019",
-                    "2018",
-                    "2017",
-                    "2016",
-                    "2015",
-                    "2014",
-                    "2013",
-                    "2012",
-                    "2011",
-                    "2010",
-                    "2009",
-                    "2008",
-                    "2007",
-                    "2006",
-                    "2005",
-                    "2004"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "id": "tmdb.language",
-              "type": "movie",
-              "name": "Idioma",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "Spanish",
-                    "Afrikaans",
-                    "Albanian",
-                    "Arabic",
-                    "Basque",
-                    "Belarusian",
-                    "Bengali",
-                    "Breton",
-                    "Bulgarian",
-                    "Catalan",
-                    "Chamorro",
-                    "Croatian",
-                    "Czech",
-                    "Danish",
-                    "Dutch",
-                    "English",
-                    "Esperanto",
-                    "Estonian",
-                    "Finnish",
-                    "French",
-                    "Gaelic",
-                    "Galician",
-                    "Georgian",
-                    "German",
-                    "Greek",
-                    "Hebrew",
-                    "Hindi",
-                    "Hungarian",
-                    "Indonesian",
-                    "Irish",
-                    "Italian",
-                    "Japanese",
-                    "Kannada",
-                    "Kazakh",
-                    "Kirghiz",
-                    "Korean",
-                    "Kurdish",
-                    "Latvian",
-                    "Lithuanian",
-                    "Malay",
-                    "Malayalam",
-                    "Mandarin",
-                    "Marathi",
-                    "Norwegian",
-                    "Norwegian Bokmål",
-                    "Persian",
-                    "Polish",
-                    "Portuguese",
-                    "Punjabi",
-                    "Romanian",
-                    "Russian",
-                    "Serbian",
-                    "Sinhalese",
-                    "Slovak",
-                    "Slovenian",
-                    "Somali",
-                    "Swahili",
-                    "Swedish",
-                    "Tagalog",
-                    "Tamil",
-                    "Telugu",
-                    "Thai",
-                    "Turkish",
-                    "Ukrainian",
-                    "Urdu",
-                    "Uzbek",
-                    "Vietnamese",
-                    "Welsh",
-                    "Zulu"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "id": "tmdb.trending",
-              "type": "movie",
-              "name": "Tendencia",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "Day",
-                    "Week"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "id": "tmdb.top",
-              "type": "series",
-              "name": "Popular",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "",
-                    "Action & Adventure",
-                    "Animación",
-                    "Comedia",
-                    "Crimen",
-                    "Documental",
-                    "Drama",
-                    "Familia",
-                    "Kids",
-                    "Misterio",
-                    "News",
-                    "Reality",
-                    "Sci-Fi & Fantasy",
-                    "Soap",
-                    "Talk",
-                    "War & Politics",
-                    "Western"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "search",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "id": "tmdb.year",
-              "type": "series",
-              "name": "Año",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "2024",
-                    "2023",
-                    "2022",
-                    "2021",
-                    "2020",
-                    "2019",
-                    "2018",
-                    "2017",
-                    "2016",
-                    "2015",
-                    "2014",
-                    "2013",
-                    "2012",
-                    "2011",
-                    "2010",
-                    "2009",
-                    "2008",
-                    "2007",
-                    "2006",
-                    "2005",
-                    "2004"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "id": "tmdb.language",
-              "type": "series",
-              "name": "Idioma",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "Spanish",
-                    "Afrikaans",
-                    "Albanian",
-                    "Arabic",
-                    "Basque",
-                    "Belarusian",
-                    "Bengali",
-                    "Breton",
-                    "Bulgarian",
-                    "Catalan",
-                    "Chamorro",
-                    "Croatian",
-                    "Czech",
-                    "Danish",
-                    "Dutch",
-                    "English",
-                    "Esperanto",
-                    "Estonian",
-                    "Finnish",
-                    "French",
-                    "Gaelic",
-                    "Galician",
-                    "Georgian",
-                    "German",
-                    "Greek",
-                    "Hebrew",
-                    "Hindi",
-                    "Hungarian",
-                    "Indonesian",
-                    "Irish",
-                    "Italian",
-                    "Japanese",
-                    "Kannada",
-                    "Kazakh",
-                    "Kirghiz",
-                    "Korean",
-                    "Kurdish",
-                    "Latvian",
-                    "Lithuanian",
-                    "Malay",
-                    "Malayalam",
-                    "Mandarin",
-                    "Marathi",
-                    "Norwegian",
-                    "Norwegian Bokmål",
-                    "Persian",
-                    "Polish",
-                    "Portuguese",
-                    "Punjabi",
-                    "Romanian",
-                    "Russian",
-                    "Serbian",
-                    "Sinhalese",
-                    "Slovak",
-                    "Slovenian",
-                    "Somali",
-                    "Swahili",
-                    "Swedish",
-                    "Tagalog",
-                    "Tamil",
-                    "Telugu",
-                    "Thai",
-                    "Turkish",
-                    "Ukrainian",
-                    "Urdu",
-                    "Uzbek",
-                    "Vietnamese",
-                    "Welsh",
-                    "Zulu"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "id": "tmdb.trending",
-              "type": "series",
-              "name": "Tendencia",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "Day",
-                    "Week"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "name": "TMDB Búsqueda Películas",
-              "type": "movie",
-              "id": "tmdb.search",
-              "extra": [
-                {
-                  "name": "search",
-                  "isRequired": true
-                }
-              ]
-            },
-            {
-              "name": "TMDB Búsqueda Series",
-              "type": "series",
-              "id": "tmdb.search",
-              "extra": [
-                {
-                  "name": "search",
-                  "isRequired": true
-                }
-              ]
-            }
-          ],
-          "addonCatalogs": [],
-          "behaviorHints": {
-            "adult": false,
-            "p2p": false,
-            "configurable": true,
-            "configurationRequired": false
-          }
-        },
-        "flags": {
-          "official": false,
-          "protected": false
-        }
-      },
-      {
         "transportUrl": "https://jackettio.elfhosted.com/eyJtYXhUb3JyZW50cyI6MTAsInByaW90aXplUGFja1RvcnJlbnRzIjoyLCJleGNsdWRlS2V5d29yZHMiOlsiQ0FNIiwiVGVsZVN5bmMiLCJUZWxlQ2luZSIsIlNDUiJdLCJkZWJyaWRJZCI6InJlYWxkZWJyaWQiLCJoaWRlVW5jYWNoZWQiOmZhbHNlLCJzb3J0Q2FjaGVkIjpbWyJxdWFsaXR5Iix0cnVlXSxbInNpemUiLHRydWVdXSwic29ydFVuY2FjaGVkIjpbWyJxdWFsaXR5Iix0cnVlXSxbInNlZWRlcnMiLHRydWVdXSwiZm9yY2VDYWNoZU5leHRFcGlzb2RlIjp0cnVlLCJwcmlvdGl6ZUxhbmd1YWdlcyI6WyJzcGFuaXNoIl0sImluZGV4ZXJUaW1lb3V0U2VjIjo2MCwibWV0YUxhbmd1YWdlIjoiIiwiZW5hYmxlTWVkaWFGbG93IjpmYWxzZSwibWVkaWFmbG93UHJveHlVcmwiOiIiLCJtZWRpYWZsb3dBcGlQYXNzd29yZCI6IiIsIm1lZGlhZmxvd1B1YmxpY0lwIjoiIiwicXVhbGl0aWVzIjpbNDgwLDcyMCwxMDgwLDIxNjBdLCJpbmRleGVycyI6WyJiaXRzZWFyY2giLCJlenR2IiwidGhlcGlyYXRlYmF5IiwidGhlcmFyYmciLCJ5dHMiXSwiZGVicmlkQXBpS2V5IjoiMCJ9/manifest.json",
         "transportName": "",
         "manifest": {
@@ -1844,116 +1989,6 @@
         "flags": {
           "official": false,
           "protected": false
-        }
-      },
-      {
-        "transportUrl": "https://v3-cinemeta.strem.io/manifest.json",
-        "transportName": "http",
-        "manifest": {
-          "id": "com.linvo.cinemeta",
-          "version": "3.0.12",
-          "description": "The official addon for movie and series catalogs",
-          "name": "Cinemeta",
-          "resources": [
-            "meta",
-            "addon_catalog",
-            "catalog"
-          ],
-          "types": [
-            "movie",
-            "series"
-          ],
-          "idPrefixes": [
-            "tt"
-          ],
-          "addonCatalogs": [
-            {
-              "type": "all",
-              "id": "official",
-              "name": "Official"
-            },
-            {
-              "type": "movie",
-              "id": "official",
-              "name": "Official"
-            },
-            {
-              "type": "series",
-              "id": "official",
-              "name": "Official"
-            },
-            {
-              "type": "channel",
-              "id": "official",
-              "name": "Official"
-            },
-            {
-              "type": "all",
-              "id": "community",
-              "name": "Community"
-            },
-            {
-              "type": "movie",
-              "id": "community",
-              "name": "Community"
-            },
-            {
-              "type": "series",
-              "id": "community",
-              "name": "Community"
-            },
-            {
-              "type": "channel",
-              "id": "community",
-              "name": "Community"
-            },
-            {
-              "type": "tv",
-              "id": "community",
-              "name": "Community"
-            },
-            {
-              "type": "Podcasts",
-              "id": "community",
-              "name": "Community"
-            },
-            {
-              "type": "other",
-              "id": "community",
-              "name": "Community"
-            }
-          ],
-          "catalogs": [
-            {
-              "name": "Cinemeta Búsqueda Películas",
-              "type": "movie",
-              "id": "cinemeta.search",
-              "extra": [
-                {
-                  "name": "search",
-                  "isRequired": true
-                }
-              ]
-            },
-            {
-              "name": "Cinemeta Búsqueda Series",
-              "type": "series",
-              "id": "cinemeta.search",
-              "extra": [
-                {
-                  "name": "search",
-                  "isRequired": true
-                }
-              ]
-            }
-          ],
-          "behaviorHints": {
-            "newEpisodeNotifications": true
-          }
-        },
-        "flags": {
-          "official": true,
-          "protected": true
         }
       },
       {

--- a/public/presets/pt.json
+++ b/public/presets/pt.json
@@ -2,6 +2,605 @@
   "result": {
     "addons": [
       {
+        "transportUrl": "https://v3-cinemeta.strem.io/manifest.json",
+        "transportName": "http",
+        "manifest": {
+          "id": "com.linvo.cinemeta",
+          "version": "3.0.13",
+          "description": "The official addon for movie and series catalogs",
+          "name": "Cinemeta",
+          "resources": [
+            "catalog",
+            "meta",
+            "addon_catalog"
+          ],
+          "types": [
+            "movie",
+            "series"
+          ],
+          "idPrefixes": [
+            "tt"
+          ],
+          "addonCatalogs": [
+            {
+              "type": "all",
+              "id": "official",
+              "name": "Official"
+            },
+            {
+              "type": "movie",
+              "id": "official",
+              "name": "Official"
+            },
+            {
+              "type": "series",
+              "id": "official",
+              "name": "Official"
+            },
+            {
+              "type": "channel",
+              "id": "official",
+              "name": "Official"
+            },
+            {
+              "type": "all",
+              "id": "community",
+              "name": "Community"
+            },
+            {
+              "type": "movie",
+              "id": "community",
+              "name": "Community"
+            },
+            {
+              "type": "series",
+              "id": "community",
+              "name": "Community"
+            },
+            {
+              "type": "channel",
+              "id": "community",
+              "name": "Community"
+            },
+            {
+              "type": "tv",
+              "id": "community",
+              "name": "Community"
+            },
+            {
+              "type": "Podcasts",
+              "id": "community",
+              "name": "Community"
+            },
+            {
+              "type": "other",
+              "id": "community",
+              "name": "Community"
+            }
+          ],
+          "catalogs": [
+            {
+              "name": "Cinemeta Search Movies",
+              "type": "movie",
+              "id": "cinemeta.search",
+              "extra": [
+                {
+                  "name": "search",
+                  "isRequired": true
+                }
+              ]
+            },
+            {
+              "name": "Cinemeta Search TV Shows",
+              "type": "series",
+              "id": "cinemeta.search",
+              "extra": [
+                {
+                  "name": "search",
+                  "isRequired": true
+                }
+              ]
+            },
+            {
+              "type": "series",
+              "id": "last-videos",
+              "name": "Últimos vídeos",
+              "extra": [
+                {
+                  "name": "lastVideosIds",
+                  "isRequired": true,
+                  "optionsLimit": 100
+                }
+              ],
+              "extraSupported": [
+                "lastVideosIds"
+              ],
+              "extraRequired": [
+                "lastVideosIds"
+              ]
+            },
+            {
+              "type": "series",
+              "id": "calendar-videos",
+              "extra": [
+                {
+                  "name": "calendarVideosIds",
+                  "isRequired": true,
+                  "optionsLimit": 100
+                }
+              ],
+              "extraSupported": [
+                "calendarVideosIds"
+              ],
+              "extraRequired": [
+                "calendarVideosIds"
+              ],
+              "name": "Vídeos do calendário"
+            }
+          ],
+          "behaviorHints": {
+            "newEpisodeNotifications": true
+          }
+        },
+        "flags": {
+          "official": true,
+          "protected": true
+        }
+      },
+      {
+        "transportUrl": "https://94c8cb9f702d-tmdb-addon.baby-beamup.club/%7B%22provide_imdbId%22%3A%22true%22%2C%22language%22%3A%22pt-BR%22%7D/manifest.json",
+        "transportName": "",
+        "manifest": {
+          "id": "tmdb-addon",
+          "version": "3.0.18",
+          "name": "The Movie Database Addon",
+          "contactEmail": null,
+          "description": "Metadata provided by TMDB with pt-BR language.",
+          "logo": "https://github.com/mrcanelas/tmdb-addon/raw/main/images/logo.png",
+          "background": "https://github.com/mrcanelas/tmdb-addon/raw/main/images/background.png",
+          "types": [
+            "movie",
+            "series"
+          ],
+          "resources": [
+            "catalog",
+            "meta"
+          ],
+          "idPrefixes": [
+            "tmdb:",
+            "tt"
+          ],
+          "catalogs": [
+            {
+              "id": "tmdb.top",
+              "type": "movie",
+              "name": "Popular",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "",
+                    "Animação",
+                    "Aventura",
+                    "Ação",
+                    "Cinema TV",
+                    "Comédia",
+                    "Crime",
+                    "Documentário",
+                    "Drama",
+                    "Família",
+                    "Fantasia",
+                    "Faroeste",
+                    "Ficção científica",
+                    "Guerra",
+                    "História",
+                    "Mistério",
+                    "Música",
+                    "Romance",
+                    "Terror",
+                    "Thriller"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "search",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "id": "tmdb.year",
+              "type": "movie",
+              "name": "Ano",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "2025",
+                    "2024",
+                    "2023",
+                    "2022",
+                    "2021",
+                    "2020",
+                    "2019",
+                    "2018",
+                    "2017",
+                    "2016",
+                    "2015",
+                    "2014",
+                    "2013",
+                    "2012",
+                    "2011",
+                    "2010",
+                    "2009",
+                    "2008",
+                    "2007",
+                    "2006",
+                    "2005"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "id": "tmdb.language",
+              "type": "movie",
+              "name": "Idioma",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "Portuguese",
+                    "Afrikaans",
+                    "Albanian",
+                    "Arabic",
+                    "Basque",
+                    "Belarusian",
+                    "Bengali",
+                    "Breton",
+                    "Bulgarian",
+                    "Catalan",
+                    "Chamorro",
+                    "Croatian",
+                    "Czech",
+                    "Danish",
+                    "Dutch",
+                    "English",
+                    "Esperanto",
+                    "Estonian",
+                    "Finnish",
+                    "French",
+                    "Gaelic",
+                    "Galician",
+                    "Georgian",
+                    "German",
+                    "Greek",
+                    "Hebrew",
+                    "Hindi",
+                    "Hungarian",
+                    "Indonesian",
+                    "Irish",
+                    "Italian",
+                    "Japanese",
+                    "Kannada",
+                    "Kazakh",
+                    "Kirghiz",
+                    "Korean",
+                    "Kurdish",
+                    "Latvian",
+                    "Lithuanian",
+                    "Malay",
+                    "Malayalam",
+                    "Mandarin",
+                    "Marathi",
+                    "Norwegian",
+                    "Norwegian Bokmål",
+                    "Persian",
+                    "Polish",
+                    "Punjabi",
+                    "Romanian",
+                    "Russian",
+                    "Serbian",
+                    "Sinhalese",
+                    "Slovak",
+                    "Slovenian",
+                    "Somali",
+                    "Spanish",
+                    "Swahili",
+                    "Swedish",
+                    "Tagalog",
+                    "Tamil",
+                    "Telugu",
+                    "Thai",
+                    "Turkish",
+                    "Ukrainian",
+                    "Urdu",
+                    "Uzbek",
+                    "Vietnamese",
+                    "Welsh",
+                    "Zulu"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "id": "tmdb.trending",
+              "type": "movie",
+              "name": "Tendência",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "Day",
+                    "Week"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "id": "tmdb.top",
+              "type": "series",
+              "name": "Popular",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "",
+                    "Action & Adventure",
+                    "Animação",
+                    "Comédia",
+                    "Crime",
+                    "Documentário",
+                    "Drama",
+                    "Família",
+                    "Faroeste",
+                    "Kids",
+                    "Mistério",
+                    "News",
+                    "Reality",
+                    "Sci-Fi & Fantasy",
+                    "Soap",
+                    "Talk",
+                    "War & Politics"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "search",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "id": "tmdb.year",
+              "type": "series",
+              "name": "Ano",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "2025",
+                    "2024",
+                    "2023",
+                    "2022",
+                    "2021",
+                    "2020",
+                    "2019",
+                    "2018",
+                    "2017",
+                    "2016",
+                    "2015",
+                    "2014",
+                    "2013",
+                    "2012",
+                    "2011",
+                    "2010",
+                    "2009",
+                    "2008",
+                    "2007",
+                    "2006",
+                    "2005"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "id": "tmdb.language",
+              "type": "series",
+              "name": "Idioma",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "Portuguese",
+                    "Afrikaans",
+                    "Albanian",
+                    "Arabic",
+                    "Basque",
+                    "Belarusian",
+                    "Bengali",
+                    "Breton",
+                    "Bulgarian",
+                    "Catalan",
+                    "Chamorro",
+                    "Croatian",
+                    "Czech",
+                    "Danish",
+                    "Dutch",
+                    "English",
+                    "Esperanto",
+                    "Estonian",
+                    "Finnish",
+                    "French",
+                    "Gaelic",
+                    "Galician",
+                    "Georgian",
+                    "German",
+                    "Greek",
+                    "Hebrew",
+                    "Hindi",
+                    "Hungarian",
+                    "Indonesian",
+                    "Irish",
+                    "Italian",
+                    "Japanese",
+                    "Kannada",
+                    "Kazakh",
+                    "Kirghiz",
+                    "Korean",
+                    "Kurdish",
+                    "Latvian",
+                    "Lithuanian",
+                    "Malay",
+                    "Malayalam",
+                    "Mandarin",
+                    "Marathi",
+                    "Norwegian",
+                    "Norwegian Bokmål",
+                    "Persian",
+                    "Polish",
+                    "Punjabi",
+                    "Romanian",
+                    "Russian",
+                    "Serbian",
+                    "Sinhalese",
+                    "Slovak",
+                    "Slovenian",
+                    "Somali",
+                    "Spanish",
+                    "Swahili",
+                    "Swedish",
+                    "Tagalog",
+                    "Tamil",
+                    "Telugu",
+                    "Thai",
+                    "Turkish",
+                    "Ukrainian",
+                    "Urdu",
+                    "Uzbek",
+                    "Vietnamese",
+                    "Welsh",
+                    "Zulu"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "id": "tmdb.trending",
+              "type": "series",
+              "name": "Tendência",
+              "extra": [
+                {
+                  "name": "genre",
+                  "isRequired": true,
+                  "options": [
+                    "Day",
+                    "Week"
+                  ],
+                  "optionsLimit": 1
+                },
+                {
+                  "name": "skip",
+                  "isRequired": false,
+                  "options": [],
+                  "optionsLimit": 1
+                }
+              ]
+            },
+            {
+              "name": "TMDB Pesquisa Filmes",
+              "type": "movie",
+              "id": "tmdb.search",
+              "extra": [
+                {
+                  "name": "search",
+                  "isRequired": true
+                }
+              ]
+            },
+            {
+              "name": "TMDB Pesquisa Série",
+              "type": "series",
+              "id": "tmdb.search",
+              "extra": [
+                {
+                  "name": "search",
+                  "isRequired": true
+                }
+              ]
+            }
+          ],
+          "addonCatalogs": [],
+          "behaviorHints": {
+            "adult": false,
+            "p2p": false,
+            "configurable": true,
+            "configurationRequired": false
+          }
+        },
+        "flags": {
+          "official": false,
+          "protected": false
+        }
+      },
+      {
         "transportUrl": "https://2ecbbd610840-trakt.baby-beamup.club/eyJsaXN0cyI6W10sImlkcyI6WyJnYXJ5Y3Jhd2ZvcmRnYzpsYXRlc3QtcmVsZWFzZXM6cmVsZWFzZWQsYXNjIiwiZ2FyeWNyYXdmb3JkZ2M6bGF0ZXN0LXR2LXNob3dzOnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOnRvcC1tb3ZpZXMtb2YtdGhlLXdlZWs6cmVsZWFzZWQsYXNjIiwiZ2FyeWNyYXdmb3JkZ2M6bmV0ZmxpeC1tb3ZpZXM6cmVsZWFzZWQsYXNjIiwiZ2FyeWNyYXdmb3JkZ2M6bmV0ZmxpeC1zaG93czpyZWxlYXNlZCxhc2MiLCJnYXJ5Y3Jhd2ZvcmRnYzpkaXNuZXktbW92aWVzOnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOmRpc25leS1zaG93czpyZWxlYXNlZCxhc2MiLCJnYXJ5Y3Jhd2ZvcmRnYzphbWF6b24tcHJpbWUtbW92aWVzOnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOmFtYXpvbi1wcmltZS1zaG93czpyZWxlYXNlZCxhc2MiLCJnYXJ5Y3Jhd2ZvcmRnYzpodWx1LW1vdmllczpyZWxlYXNlZCxhc2MiLCJnYXJ5Y3Jhd2ZvcmRnYzpodWx1LXNob3dzOnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOmhiby1zaG93czpyZWxlYXNlZCxhc2MiLCJnYXJ5Y3Jhd2ZvcmRnYzphY3Rpb246cmVsZWFzZWQsYXNjIiwicml6cmVmbGVjdHM6YWR2ZW50dXJlLW1vdmllczpyZWxlYXNlZCxhc2MiLCJyaXpyZWZsZWN0czphbmltYXRpb246cmVsZWFzZWQsYXNjIiwiZ2FyeWNyYXdmb3JkZ2M6Y29tZWR5OnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOmNyaW1lOnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOmRyYW1hOnJlbGVhc2VkLGFzYyIsInJpenJlZmxlY3RzOmZhbnRhc3ktbW92aWVzOnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOmhvcnJvcjpyZWxlYXNlZCxhc2MiLCJyaXpyZWZsZWN0czpteXN0ZXJ5LW1vdmllczpyZWxlYXNlZCxhc2MiLCJyaXpyZWZsZWN0czpyb21hbmNlOnJlbGVhc2VkLGFzYyIsImdhcnljcmF3Zm9yZGdjOnNjaS1maTpyZWxlYXNlZCxhc2MiLCJnYXJ5Y3Jhd2ZvcmRnYzp0aHJpbGxlcjpyZWxlYXNlZCxhc2MiXX0=/manifest.json",
         "transportName": "",
         "manifest": {
@@ -1198,459 +1797,6 @@
         }
       },
       {
-        "transportUrl": "https://94c8cb9f702d-tmdb-addon.baby-beamup.club/%7B%22provide_imdbId%22%3A%22true%22%2C%22language%22%3A%22pt-BR%22%7D/manifest.json",
-        "transportName": "",
-        "manifest": {
-          "id": "tmdb-addon",
-          "version": "3.0.18",
-          "name": "The Movie Database Addon",
-          "contactEmail": null,
-          "description": "Metadata provided by TMDB with pt-BR language.",
-          "logo": "https://github.com/mrcanelas/tmdb-addon/raw/main/images/logo.png",
-          "background": "https://github.com/mrcanelas/tmdb-addon/raw/main/images/background.png",
-          "types": [
-            "movie",
-            "series"
-          ],
-          "resources": [
-            "catalog",
-            "meta"
-          ],
-          "idPrefixes": [
-            "tmdb:",
-            "tt"
-          ],
-          "catalogs": [
-            {
-              "id": "tmdb.top",
-              "type": "movie",
-              "name": "Popular",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "",
-                    "Animação",
-                    "Aventura",
-                    "Ação",
-                    "Cinema TV",
-                    "Comédia",
-                    "Crime",
-                    "Documentário",
-                    "Drama",
-                    "Família",
-                    "Fantasia",
-                    "Faroeste",
-                    "Ficção científica",
-                    "Guerra",
-                    "História",
-                    "Mistério",
-                    "Música",
-                    "Romance",
-                    "Terror",
-                    "Thriller"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "search",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "id": "tmdb.year",
-              "type": "movie",
-              "name": "Ano",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "2024",
-                    "2023",
-                    "2022",
-                    "2021",
-                    "2020",
-                    "2019",
-                    "2018",
-                    "2017",
-                    "2016",
-                    "2015",
-                    "2014",
-                    "2013",
-                    "2012",
-                    "2011",
-                    "2010",
-                    "2009",
-                    "2008",
-                    "2007",
-                    "2006",
-                    "2005",
-                    "2004"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "id": "tmdb.language",
-              "type": "movie",
-              "name": "Idioma",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "Portuguese",
-                    "Afrikaans",
-                    "Albanian",
-                    "Arabic",
-                    "Basque",
-                    "Belarusian",
-                    "Bengali",
-                    "Breton",
-                    "Bulgarian",
-                    "Catalan",
-                    "Chamorro",
-                    "Croatian",
-                    "Czech",
-                    "Danish",
-                    "Dutch",
-                    "English",
-                    "Esperanto",
-                    "Estonian",
-                    "Finnish",
-                    "French",
-                    "Gaelic",
-                    "Galician",
-                    "Georgian",
-                    "German",
-                    "Greek",
-                    "Hebrew",
-                    "Hindi",
-                    "Hungarian",
-                    "Indonesian",
-                    "Irish",
-                    "Italian",
-                    "Japanese",
-                    "Kannada",
-                    "Kazakh",
-                    "Kirghiz",
-                    "Korean",
-                    "Kurdish",
-                    "Latvian",
-                    "Lithuanian",
-                    "Malay",
-                    "Malayalam",
-                    "Mandarin",
-                    "Marathi",
-                    "Norwegian",
-                    "Norwegian Bokmål",
-                    "Persian",
-                    "Polish",
-                    "Punjabi",
-                    "Romanian",
-                    "Russian",
-                    "Serbian",
-                    "Sinhalese",
-                    "Slovak",
-                    "Slovenian",
-                    "Somali",
-                    "Spanish",
-                    "Swahili",
-                    "Swedish",
-                    "Tagalog",
-                    "Tamil",
-                    "Telugu",
-                    "Thai",
-                    "Turkish",
-                    "Ukrainian",
-                    "Urdu",
-                    "Uzbek",
-                    "Vietnamese",
-                    "Welsh",
-                    "Zulu"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "id": "tmdb.trending",
-              "type": "movie",
-              "name": "Tendência",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "Day",
-                    "Week"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "id": "tmdb.top",
-              "type": "series",
-              "name": "Popular",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "",
-                    "Action & Adventure",
-                    "Animação",
-                    "Comédia",
-                    "Crime",
-                    "Documentário",
-                    "Drama",
-                    "Família",
-                    "Faroeste",
-                    "Kids",
-                    "Mistério",
-                    "News",
-                    "Reality",
-                    "Sci-Fi & Fantasy",
-                    "Soap",
-                    "Talk",
-                    "War & Politics"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "search",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "id": "tmdb.year",
-              "type": "series",
-              "name": "Ano",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "2024",
-                    "2023",
-                    "2022",
-                    "2021",
-                    "2020",
-                    "2019",
-                    "2018",
-                    "2017",
-                    "2016",
-                    "2015",
-                    "2014",
-                    "2013",
-                    "2012",
-                    "2011",
-                    "2010",
-                    "2009",
-                    "2008",
-                    "2007",
-                    "2006",
-                    "2005",
-                    "2004"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "id": "tmdb.language",
-              "type": "series",
-              "name": "Idioma",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "Portuguese",
-                    "Afrikaans",
-                    "Albanian",
-                    "Arabic",
-                    "Basque",
-                    "Belarusian",
-                    "Bengali",
-                    "Breton",
-                    "Bulgarian",
-                    "Catalan",
-                    "Chamorro",
-                    "Croatian",
-                    "Czech",
-                    "Danish",
-                    "Dutch",
-                    "English",
-                    "Esperanto",
-                    "Estonian",
-                    "Finnish",
-                    "French",
-                    "Gaelic",
-                    "Galician",
-                    "Georgian",
-                    "German",
-                    "Greek",
-                    "Hebrew",
-                    "Hindi",
-                    "Hungarian",
-                    "Indonesian",
-                    "Irish",
-                    "Italian",
-                    "Japanese",
-                    "Kannada",
-                    "Kazakh",
-                    "Kirghiz",
-                    "Korean",
-                    "Kurdish",
-                    "Latvian",
-                    "Lithuanian",
-                    "Malay",
-                    "Malayalam",
-                    "Mandarin",
-                    "Marathi",
-                    "Norwegian",
-                    "Norwegian Bokmål",
-                    "Persian",
-                    "Polish",
-                    "Punjabi",
-                    "Romanian",
-                    "Russian",
-                    "Serbian",
-                    "Sinhalese",
-                    "Slovak",
-                    "Slovenian",
-                    "Somali",
-                    "Spanish",
-                    "Swahili",
-                    "Swedish",
-                    "Tagalog",
-                    "Tamil",
-                    "Telugu",
-                    "Thai",
-                    "Turkish",
-                    "Ukrainian",
-                    "Urdu",
-                    "Uzbek",
-                    "Vietnamese",
-                    "Welsh",
-                    "Zulu"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "id": "tmdb.trending",
-              "type": "series",
-              "name": "Tendência",
-              "extra": [
-                {
-                  "name": "genre",
-                  "isRequired": true,
-                  "options": [
-                    "Day",
-                    "Week"
-                  ],
-                  "optionsLimit": 1
-                },
-                {
-                  "name": "skip",
-                  "isRequired": false,
-                  "options": [],
-                  "optionsLimit": 1
-                }
-              ]
-            },
-            {
-              "name": "TMDB Pesquisa Filmes",
-              "type": "movie",
-              "id": "tmdb.search",
-              "extra": [
-                {
-                  "name": "search",
-                  "isRequired": true
-                }
-              ]
-            },
-            {
-              "name": "TMDB Pesquisa Série",
-              "type": "series",
-              "id": "tmdb.search",
-              "extra": [
-                {
-                  "name": "search",
-                  "isRequired": true
-                }
-              ]
-            }
-          ],
-          "addonCatalogs": [],
-          "behaviorHints": {
-            "adult": false,
-            "p2p": false,
-            "configurable": true,
-            "configurationRequired": false
-          }
-        },
-        "flags": {
-          "official": false,
-          "protected": false
-        }
-      },
-      {
         "transportUrl": "https://jackettio.elfhosted.com/eyJtYXhUb3JyZW50cyI6MTAsInByaW90aXplUGFja1RvcnJlbnRzIjoyLCJleGNsdWRlS2V5d29yZHMiOlsiQ0FNIiwiVGVsZVN5bmMiLCJUZWxlQ2luZSIsIlNDUiJdLCJkZWJyaWRJZCI6InJlYWxkZWJyaWQiLCJoaWRlVW5jYWNoZWQiOmZhbHNlLCJzb3J0Q2FjaGVkIjpbWyJxdWFsaXR5Iix0cnVlXSxbInNpemUiLHRydWVdXSwic29ydFVuY2FjaGVkIjpbWyJxdWFsaXR5Iix0cnVlXSxbInNlZWRlcnMiLHRydWVdXSwiZm9yY2VDYWNoZU5leHRFcGlzb2RlIjp0cnVlLCJwcmlvdGl6ZUxhbmd1YWdlcyI6WyJicmF6aWxpYW4iXSwiaW5kZXhlclRpbWVvdXRTZWMiOjYwLCJtZXRhTGFuZ3VhZ2UiOiIiLCJlbmFibGVNZWRpYUZsb3ciOmZhbHNlLCJtZWRpYWZsb3dQcm94eVVybCI6IiIsIm1lZGlhZmxvd0FwaVBhc3N3b3JkIjoiIiwibWVkaWFmbG93UHVibGljSXAiOiIiLCJxdWFsaXRpZXMiOls0ODAsNzIwLDEwODAsMjE2MF0sImluZGV4ZXJzIjpbImJpdHNlYXJjaCIsImV6dHYiLCJ0aGVwaXJhdGViYXkiLCJ0aGVyYXJiZyIsInl0cyJdLCJkZWJyaWRBcGlLZXkiOiIwIn0=/manifest.json",
         "transportName": "",
         "manifest": {
@@ -1844,116 +1990,6 @@
         "flags": {
           "official": false,
           "protected": false
-        }
-      },
-      {
-        "transportUrl": "https://v3-cinemeta.strem.io/manifest.json",
-        "transportName": "http",
-        "manifest": {
-          "id": "com.linvo.cinemeta",
-          "version": "3.0.12",
-          "description": "The official addon for movie and series catalogs",
-          "name": "Cinemeta",
-          "resources": [
-            "meta",
-            "addon_catalog",
-            "catalog"
-          ],
-          "types": [
-            "movie",
-            "series"
-          ],
-          "idPrefixes": [
-            "tt"
-          ],
-          "addonCatalogs": [
-            {
-              "type": "all",
-              "id": "official",
-              "name": "Official"
-            },
-            {
-              "type": "movie",
-              "id": "official",
-              "name": "Official"
-            },
-            {
-              "type": "series",
-              "id": "official",
-              "name": "Official"
-            },
-            {
-              "type": "channel",
-              "id": "official",
-              "name": "Official"
-            },
-            {
-              "type": "all",
-              "id": "community",
-              "name": "Community"
-            },
-            {
-              "type": "movie",
-              "id": "community",
-              "name": "Community"
-            },
-            {
-              "type": "series",
-              "id": "community",
-              "name": "Community"
-            },
-            {
-              "type": "channel",
-              "id": "community",
-              "name": "Community"
-            },
-            {
-              "type": "tv",
-              "id": "community",
-              "name": "Community"
-            },
-            {
-              "type": "Podcasts",
-              "id": "community",
-              "name": "Community"
-            },
-            {
-              "type": "other",
-              "id": "community",
-              "name": "Community"
-            }
-          ],
-          "catalogs": [
-            {
-              "name": "Cinemeta Pesquisa Filmes",
-              "type": "movie",
-              "id": "cinemeta.search",
-              "extra": [
-                {
-                  "name": "search",
-                  "isRequired": true
-                }
-              ]
-            },
-            {
-              "name": "Cinemeta Pesquisa Série",
-              "type": "series",
-              "id": "cinemeta.search",
-              "extra": [
-                {
-                  "name": "search",
-                  "isRequired": true
-                }
-              ]
-            }
-          ],
-          "behaviorHints": {
-            "newEpisodeNotifications": true
-          }
-        },
-        "flags": {
-          "official": true,
-          "protected": true
         }
       },
       {

--- a/src/components/Configuration.vue
+++ b/src/components/Configuration.vue
@@ -76,10 +76,10 @@ function loadUserAddons() {
 
           // Comet
           const cometTransportUrl = getDataTransportUrl(
-            presetConfig[2].transportUrl
+            presetConfig[4].transportUrl
           );
-          presetConfig[2].manifest.name += ` | ${debridServiceName}`;
-          presetConfig[2].transportUrl = getUrlTransportUrl(cometTransportUrl, {
+          presetConfig[4].manifest.name += ` | ${debridServiceName}`;
+          presetConfig[4].transportUrl = getUrlTransportUrl(cometTransportUrl, {
             ...cometTransportUrl.data,
             debridApiKey: debridApiKey.value,
             debridService: debridService.value
@@ -88,34 +88,34 @@ function loadUserAddons() {
           // Jackettio
           if (debridService.value !== 'torbox') {
             const jackettioTransportUrl = getDataTransportUrl(
-              presetConfig[4].transportUrl
+              presetConfig[5].transportUrl
             );
-            presetConfig[4].manifest.name += ` ${debridServiceName}`;
-            presetConfig[4].transportUrl = getUrlTransportUrl(jackettioTransportUrl, {
+            presetConfig[5].manifest.name += ` ${debridServiceName}`;
+            presetConfig[5].transportUrl = getUrlTransportUrl(jackettioTransportUrl, {
               ...jackettioTransportUrl.data,
               debridApiKey: debridApiKey.value,
               debridId: debridService.value
             });
           } else {
-            presetConfig.splice(4, 1);
+            presetConfig.splice(5, 1);
           }
 
           // Remove MediaFusion / KnightCrawler / TPB+
-          presetConfig.splice(5, 3);
+          presetConfig.splice(6, 3);
         } else {
           debridServiceName = '';
 
           // Remove Jackettio
-          presetConfig.splice(4, 1);
+          presetConfig.splice(5, 1);
         }
 
         if (!!rpdbKey.value) {
           // Trakt TV
           const traktTransportUrl = getDataTransportUrl(
-            presetConfig[0].transportUrl
+            presetConfig[2].transportUrl
           );
 
-          presetConfig[0].transportUrl = getUrlTransportUrl(traktTransportUrl, {
+          presetConfig[2].transportUrl = getUrlTransportUrl(traktTransportUrl, {
             ...traktTransportUrl.data,
             RPDBkey: {
               key: rpdbKey.value,
@@ -133,11 +133,11 @@ function loadUserAddons() {
 
           // TMDB
           const tmdbTransportUrl = getDataTransportUrl(
-            presetConfig[3].transportUrl,
+            presetConfig[1].transportUrl,
             false
           );
 
-          presetConfig[3].transportUrl = getUrlTransportUrl(
+          presetConfig[1].transportUrl = getUrlTransportUrl(
             tmdbTransportUrl,
             {
               ...tmdbTransportUrl.data,
@@ -150,11 +150,11 @@ function loadUserAddons() {
 
         if (language.value !== 'factory') {
           // Torrentio
-          presetConfig[1].transportUrl = Sqrl.render(
-            presetConfig[1].transportUrl,
+          presetConfig[3].transportUrl = Sqrl.render(
+            presetConfig[3].transportUrl,
             { transportUrl: torrentioConfig }
           );
-          presetConfig[1].manifest.name += ` ${debridServiceName}`;
+          presetConfig[3].manifest.name += ` ${debridServiceName}`;
         }
 
         addons.value = presetConfig;


### PR DESCRIPTION
This PR restores Cinemeta calendar functionality.

To get it working Cinemata and TMDB had to be moved to the top of the addons in the `en.json`, `es.json`, and `pt.json` files.

The corresponding indices in the `Configuration.vue` were updated to match the reordering of the addons.
