### PR TITLE
Add custom addons support, addon update script, and loading spinner when fetching addons.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "dependencies": {
         "@vercel/analytics": "^1.1.2",
+        "axios": "^0.21.1",
         "buffer": "^6.0.3",
+        "chalk": "^4.1.0",
         "chota": "^0.9.2",
         "date-fns": "^4.1.0",
         "lodash": "^4.17.21",
@@ -789,6 +791,30 @@
       "integrity": "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==",
       "license": "MIT"
     },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -833,10 +859,44 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/chota": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/chota/-/chota-0.9.2.tgz",
       "integrity": "sha512-DmCHT/R+yMr/aYQuokkJeNIjknSgpMpM9mR0tDlqPu8A+lGo9TS/KFPpze5Q9PPrCWenp/VG7Y10usyNDoIygQ=="
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -910,6 +970,26 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -922,6 +1002,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ieee754": {
@@ -1076,6 +1165,18 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   },
   "dependencies": {
     "@vercel/analytics": "^1.1.2",
+    "axios": "^0.21.1",
     "buffer": "^6.0.3",
+    "chalk": "^4.1.0",
     "chota": "^0.9.2",
     "date-fns": "^4.1.0",
     "lodash": "^4.17.21",

--- a/scripts/update-addons-list.json
+++ b/scripts/update-addons-list.json
@@ -1,0 +1,3 @@
+[
+  "../public/preset.json"
+]

--- a/scripts/update-addons.js
+++ b/scripts/update-addons.js
@@ -1,0 +1,148 @@
+import axios from 'axios';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import chalk from 'chalk';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Read the list of files from "update-addons-list.json"
+const updateListPath = path.join(__dirname, 'update-addons-list.json');
+let filesToUpdate = [];
+
+try {
+    const fileContent = fs.readFileSync(updateListPath, 'utf-8');
+    const fileList = JSON.parse(fileContent);
+
+    // If each item is an object with {file, enabled}, filter disabled files
+    filesToUpdate = fileList
+        .filter(item => {
+            if (typeof item === 'string') return true;          // simple string
+            if (item.enabled === undefined) return true;       // object without enabled
+            return item.enabled;                               // object with enabled: true
+        })
+        .map(item => (typeof item === 'string' ? item : item.file))
+        .map(file => path.join(__dirname, file));
+} catch (error) {
+    console.error(chalk.red(`Failed to read update-addons-list.json: ${error.message}`));
+    process.exit(1);
+}
+
+// Function to update version in JSON string while preserving formatting
+function updateVersionInJsonString(jsonString, transportUrl, newVersion) {
+    // Find the addon section by transportUrl
+    const transportUrlIndex = jsonString.indexOf(`"transportUrl": "${transportUrl}"`);
+    if (transportUrlIndex === -1) return jsonString;
+
+    // Find the start of this addon object
+    let addonStart = jsonString.lastIndexOf('{', transportUrlIndex);
+    if (addonStart === -1) return jsonString;
+
+    // Find the end of this addon object
+    let braceCount = 1;
+    let addonEnd = transportUrlIndex + `"transportUrl": "${transportUrl}"`.length;
+    while (braceCount > 0 && addonEnd < jsonString.length) {
+        if (jsonString[addonEnd] === '{') braceCount++;
+        if (jsonString[addonEnd] === '}') braceCount--;
+        addonEnd++;
+    }
+    if (braceCount !== 0) return jsonString;
+
+    // Extract the addon object
+    const addonObject = jsonString.substring(addonStart, addonEnd);
+
+    // Find the version field in this addon
+    const versionRegex = /("version":\s*")([^"]*)(")/;
+    const match = addonObject.match(versionRegex);
+    if (!match) return jsonString;
+
+    // Replace only the version value
+    const oldVersion = match[2];
+    if (oldVersion === newVersion) return jsonString;
+
+    const updatedAddon = addonObject.replace(versionRegex, `$1${newVersion}$3`);
+    return jsonString.substring(0, addonStart) + updatedAddon + jsonString.substring(addonEnd);
+}
+
+async function checkAndUpdateAddons(filePath) {
+    console.log(chalk.yellow(`Updating file: ${filePath}`));
+
+    let addonsData;
+    let upToDate = true;
+
+    try {
+        const fileContent = fs.readFileSync(filePath, 'utf-8');
+        addonsData = JSON.parse(fileContent);
+    } catch (error) {
+        console.error(chalk.red(`Failed to parse JSON file ${filePath}:`, error.message));
+        return;
+    }
+
+    // Read original file content to preserve formatting
+    let originalFileContent = fs.readFileSync(filePath, 'utf-8');
+    let updatedFileContent = originalFileContent;
+
+    let addons = [];
+
+    // Find addons in the data structure
+    if (addonsData.result && addonsData.result.addons) {
+        addons = addonsData.result.addons;
+    } else if (addonsData.addons) {
+        // Handle object structure
+        if (Array.isArray(addonsData.addons)) {
+            addons = addonsData.addons;
+        } else {
+            addons = Object.values(addonsData.addons);
+        }
+    } else {
+        console.error(chalk.red(`Could not find addons in ${filePath}`));
+        return;
+    }
+
+    // Process each addon
+    for (let addon of addons) {
+        if (!addon.transportUrl) {
+            console.log(chalk.yellow(`Skipping ${addon.manifest?.name || 'addon with no name'} because it has no transportUrl.`));
+            continue;
+        }
+
+        try {
+            const response = await axios.get(addon.transportUrl);
+            const remoteManifest = response.data;
+
+            if (remoteManifest.version && remoteManifest.version !== addon.manifest?.version) {
+                console.log(chalk.green(`Updating ${addon.manifest.name} from version ${addon.manifest.version} to ${remoteManifest.version}`));
+                
+                // Update version in the file content while preserving formatting
+                updatedFileContent = updateVersionInJsonString(updatedFileContent, addon.transportUrl, remoteManifest.version);
+                
+                upToDate = false;
+            } else {
+                console.log(chalk.blue(`${addon.manifest?.name || 'Unknown addon'}`) + " is up to date in " + chalk.yellow(`${path.basename(filePath)}`));
+            }
+        } catch (error) {
+            if (error.message.includes('connect ECONNREFUSED 127.0.0.1:11470')) {
+                // Ignore error from stremio local files
+                continue;
+            }
+            console.error(chalk.red(`Failed to fetch manifest for ${addon.manifest?.name || addon.transportUrl}:`, error.message));
+        }
+    }
+
+    if (!upToDate) {
+        const date = new Date().toLocaleDateString('en-CA').replace(/-/g, '.');
+        const backupFilePath = path.join(path.dirname(filePath), `${path.basename(filePath, '.json')}-${date}.json`);
+        
+        // Save backup with reformatted JSON for better readability
+        fs.writeFileSync(backupFilePath, JSON.stringify(addonsData, null, 2));
+        
+        // Write updated data with preserved formatting
+        fs.writeFileSync(filePath, updatedFileContent);
+        console.log('Addons updated successfully. Backup saved as ' + chalk.green(`${path.basename(backupFilePath)}`));
+    }
+}
+
+filesToUpdate.forEach(filePath => {
+    checkAndUpdateAddons(filePath);
+});

--- a/scripts/update-addons.md
+++ b/scripts/update-addons.md
@@ -1,0 +1,48 @@
+# Addons Updater Script
+
+This Node.js script automatically checks and updates addon manifests in JSON files by comparing local versions with remote versions.
+
+---
+
+## Features
+
+*   Reads multiple JSON files containing addon data.
+*   Checks each addon for updates via its `transportUrl`.
+*   Updates local addon manifests if a newer version is found.
+*   Skips addons without a `transportUrl`.
+*   Ignores connection errors from local servers (e.g., Stremio local files).
+*   Creates timestamped backups for any updated JSON files.
+*   Provides color-coded console logs for easy status tracking.
+
+---
+
+## Supported Files
+
+The script updates the files contained in the list:
+
+`.scripts/update-addons-list.json`
+
+You can modify it to add or remove files to upate.
+
+---
+
+## Prerequisites
+
+At the project root install the proeject dependencies by running:
+
+```
+npm install
+```
+
+---
+
+## Usage
+
+To run the script, run the below command:
+
+```
+node ./scripts/update-addons.js
+```
+Only the version numbers of the addons will be updated in the original files. The copy with the date will have the full updated content.
+
+You can use a comparison tool like `diff` or `meld` to review the changes made between the original and updated files.

--- a/src/components/Configuration.vue
+++ b/src/components/Configuration.vue
@@ -59,6 +59,10 @@ let rpdbKey = ref('');
 let isEditModalVisible = ref(false);
 let currentManifest = ref({});
 let currentEditIdx = ref(null);
+let isPasteModalOpen = ref(false);
+let customJsonUrl = ref('');
+let advancedVisible = ref(false);
+let isLoading = ref(false);
 
 function loadUserAddons() {
   const key = props.stremioAuthKey;
@@ -499,6 +503,38 @@ function isValidApiKey() {
   return false;
 }
 
+function openPasteModal() {
+  isPasteModalOpen.value = true;
+}
+
+function closePasteModal() {
+  isPasteModalOpen.value = false;
+  customJsonUrl.value = '';
+}
+
+async function addCustomJsonAddon() {
+  isLoading.value = true;
+  try {
+    const response = await fetch(customJsonUrl.value);
+    const parsedJson = await response.json();
+
+    // Validate the parsed JSON
+    if (!parsedJson.id || !parsedJson.name || !parsedJson.version) {
+      throw new Error('Invalid JSON structure');
+    }
+
+    addons.value.push({
+      transportUrl: customJsonUrl.value,
+      manifest: parsedJson
+    });
+    closePasteModal();
+  } catch (error) {
+    alert('Invalid JSON URL or JSON content: ' + error.message);
+  } finally {
+    isLoading.value = false;
+  }
+}
+
 async function fetchUserData(endpoint) {
   try {
     const response = await fetch(endpoint, {
@@ -730,6 +766,15 @@ async function encryptUserData(endpoint, data) {
             />
           </template>
         </draggable>
+        <div>
+          <button :disabled="!isSyncButtonEnabled" @click="advancedVisible = !advancedVisible">
+            {{ advancedVisible ? 'Hide Advanced Options' : 'Show Advanced Options' }}
+          </button>
+          <div v-if="advancedVisible">
+            <input v-model="customJsonUrl" :placeholder="$t('step7_add_custom_addons')" />
+            <button @click="addCustomJsonAddon">Add Addon</button>
+          </div>
+        </div>
       </fieldset>
       <fieldset id="form_step8">
         <legend>{{ $t('step8_bootstrap_account') }}</legend>
@@ -757,6 +802,10 @@ async function encryptUserData(endpoint, data) {
         @update-manifest="saveManifestEdit"
       />
     </div>
+  </div>
+
+  <div v-if="isLoading" class="loading-screen">
+    <div class="spinner"></div>
   </div>
 </template>
 
@@ -807,10 +856,37 @@ async function encryptUserData(endpoint, data) {
 button {
   padding: 10px 20px;
   border: none;
-  background-color: #ffa600;
+  background-color: #7b5bf5;
   color: white;
   font-size: 16px;
   cursor: pointer;
   border-radius: 5px;
+}
+
+.loading-screen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1001;
+}
+
+.spinner {
+  border: 16px solid #f3f3f3;
+  border-top: 16px solid gray;
+  border-radius: 50%;
+  width: 120px;
+  height: 120px;
+  animation: spin 2s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
 }
 </style>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -61,6 +61,7 @@
   "step6_load_preset": "Step 6: Load preset",
   "load_addons_preset": "Load Addons Preset",
   "step7_customize_addons": "Step 7: Customize Addons (optional)",
+  "step7_add_custom_addons": "Paste the manifest URL of additional addons",
   "step8_bootstrap_account": "Step 8: Bootstrap account",
   "sync_to_stremio": "Sync to Stremio",
   "edit_manifest": "Edit manifest",


### PR DESCRIPTION
This adds 
- An update script with instructions on usage. It only updates version numbers in the original preset.json. An additional updated copy named preset-${date}.json is created with all the updates when fetching the manifest url.
- An option for a user to add custom addons by pasting a manifest URL.
- A loading spinner when fetching addons for better user feedback.