### PR TITLE
feat: updated TamTaro's template to v2.5.2

### DIFF
--- a/src/api/aioStreamsApi.ts
+++ b/src/api/aioStreamsApi.ts
@@ -2,7 +2,7 @@ import { getRequest, postRequest, PROXY_BASE_URL } from '../utils/http';
 
 const API_BASE_URL = 'https://aiostreamsfortheweebs.midnightignite.me';
 const TEMPLATE_URL =
-  'https://raw.githubusercontent.com/Tam-Taro/SEL-Filtering-and-Sorting/1c83ef0f96c2891d94295f729d22fd7927a5487d/AIOStreams%20Templates/Tamtaro-complete-setup-template.json'; // v2.5.1
+  'https://raw.githubusercontent.com/Tam-Taro/SEL-Filtering-and-Sorting/da9464e1ad13ea7e4533abcdf09ca6b405e74905/AIOStreams%20Templates/Tamtaro-complete-setup-template.json'; // v2.5.2
 
 type AIOStreamsResponse = {
   success: boolean;


### PR DESCRIPTION
Small chore! Updates TamTaro's template to v2.5.2, where they disable mediafusion by default, fixing #15 

I tested locally with and without debrid, complete setup and all-in-one, everything works fine :)